### PR TITLE
Removing attribution requirement for CRC32

### DIFF
--- a/ConsistentSharp/Crc32.cs
+++ b/ConsistentSharp/Crc32.cs
@@ -2,6 +2,7 @@
 
 namespace ConsistentSharp
 {
+    // This code is borrowed from https://github.com/damieng/DamienGKit/blob/master/CSharp/DamienG.Library/Security/Cryptography/Crc32.cs 
     internal static class Crc32
     {
         private const uint DefaultPolynomial = 0xEDB88320;

--- a/ConsistentSharp/Crc32.cs
+++ b/ConsistentSharp/Crc32.cs
@@ -2,14 +2,6 @@
 
 namespace ConsistentSharp
 {
-    /**
-     * This code is borrowed from https://github.com/damieng/DamienGKit/blob/master/CSharp/DamienG.Library/Security/Cryptography/Crc32.cs
-     * 
-     * Copyright (c) Damien Guard.  All rights reserved.
-     * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. 
-     * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-     * Originally published at http://damieng.com/blog/2006/08/08/calculating_crc32_in_c_and_net
-     */
     internal static class Crc32
     {
         private const uint DefaultPolynomial = 0xEDB88320;


### PR DESCRIPTION
I originally wrote the code and it looks like the Apache license would conflict with your MIT so I'm removing any claims on your copy of the file - it's quite different anyway.