### PR TITLE
Support arbitrary hash algorithms via interface, default to crc3, fix deadlocks

### DIFF
--- a/ConsistentSharp/ConsistentHash.cs
+++ b/ConsistentSharp/ConsistentHash.cs
@@ -61,7 +61,7 @@ namespace ConsistentSharp
             }
             finally
             {
-                _rwlock.EnterWriteLock();
+                _rwlock.ExitWriteLock();
             }
         }
 
@@ -91,7 +91,7 @@ namespace ConsistentSharp
             }
             finally
             {
-                _rwlock.EnterWriteLock();
+                _rwlock.ExitWriteLock();
             }
         }
 

--- a/ConsistentSharp/ConsistentSharp.csproj
+++ b/ConsistentSharp/ConsistentSharp.csproj
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/tg123/ConsistentSharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/tg123/ConsistentSharp</RepositoryUrl>
     <PackageTags>Consistent hash</PackageTags>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.0'">

--- a/ConsistentSharp/Crc32HashAlgorithm.cs
+++ b/ConsistentSharp/Crc32HashAlgorithm.cs
@@ -1,0 +1,11 @@
+using System.Text;
+
+namespace ConsistentSharp
+{
+    public class Crc32HashAlgorithm : IHashAlgorithm
+    {
+        public uint HashKey(string key) {
+            return Crc32.Hash(Encoding.UTF8.GetBytes(key));
+        }
+    }
+}

--- a/ConsistentSharp/IHashAlgorithm.cs
+++ b/ConsistentSharp/IHashAlgorithm.cs
@@ -1,0 +1,7 @@
+namespace ConsistentSharp
+{
+    public interface IHashAlgorithm
+    {
+        uint HashKey(string key);
+    }
+}


### PR DESCRIPTION
Pretty simple - I'd like to use murmur32 instead of crc32 as it has better consistency across guids. So this introduces an interface that can be passed in the ctor, and defaults to crc32 🙂.

Update: Also found some deadlocks caused by entering write locks without exiting them.